### PR TITLE
Fix STS-B name reference

### DIFF
--- a/run.py
+++ b/run.py
@@ -221,7 +221,7 @@ if valid_interval_updates is not None:
 if args.no_save:
     subprocess_args += ['--no-save']
 
-if args.task == 'sts':
+if args.task == 'STS-B':
     subprocess_args += ['--regression-target', '--best-checkpoint-metric', 'loss']
 else:
     subprocess_args.append('--maximize-best-checkpoint-metric')


### PR DESCRIPTION
STS-B name reference was not changed according to previous commits. This PR fixes it so that fine-tuning for this task won't fail.