### PR TITLE
Fix NaN values in IntLayerNorm

### DIFF
--- a/fairseq/quantization/utils/quant_modules.py
+++ b/fairseq/quantization/utils/quant_modules.py
@@ -483,7 +483,7 @@ class IntLayerNorm(Module):
         
         # To be replaced with integer-sqrt kernel that produces the same output
         std_int = floor_ste.apply(torch.sqrt(var_int)) * 2 ** self.shift 
-        factor = floor_ste.apply(2**31 / std_int)
+        factor = floor_ste.apply(2**31 / (std_int + 0.0001))
         y_int = floor_ste.apply(y_int * factor / 2)
         scaling_factor = self.dim_sqrt / 2**30
 


### PR DESCRIPTION
Add an epsilon to `std_int` in the forward pass of `IntLayerNorm` to prevent `NaN` values due to multiplication of 0 by infinity.
The same result can alternatively be achieved by calling `torch.nan_to_num(y_int)`.